### PR TITLE
Allow custom instruction_proposer for GEPA

### DIFF
--- a/dspy/teleprompt/gepa/instruction_proposal.py
+++ b/dspy/teleprompt/gepa/instruction_proposal.py
@@ -1,0 +1,344 @@
+"""
+dspy.Predict-based Instruction Proposal for GEPA
+"""
+
+from typing import Any, Protocol
+
+import dspy
+from dspy.adapters.types.base_type import Type
+
+
+class InstructionProposerProtocol(Protocol):
+    """Protocol that instruction proposers must implement for GEPA integration."""
+
+    def __call__(self, current_instruction: str, reflective_dataset: list[dict[str, Any]]) -> str:
+        """Generate improved instruction based on current instruction and feedback examples.
+
+        Args:
+            current_instruction: The current instruction that needs improvement
+            reflective_dataset: List of examples with inputs, outputs, and feedback
+                               May contain dspy.Image objects or other custom types
+
+        Returns:
+            str: Improved instruction text
+        """
+        ...
+
+
+class GenerateEnhancedInstructionFromFeedback(dspy.Signature):
+    """I provided an assistant with instructions to perform a task, but the assistant's performance needs improvement based on the examples and feedback below.
+
+    Your task is to write a better instruction for the assistant that addresses the specific issues identified in the feedback.
+
+    ## Analysis Steps:
+    1. **Read the inputs carefully** and identify the input format and infer the detailed task description
+    2. **Read all the assistant responses and corresponding feedback** to understand what went wrong and what worked well
+    3. **Identify all niche and domain-specific factual information** about the task and include it in the instruction, as a lot of it may not be available to the assistant in the future
+    4. **Look for generalizable strategies** the assistant may have used successfully - include these in the instruction as well
+    5. **Address specific issues** mentioned in the feedback to prevent similar mistakes
+
+    ## Instruction Requirements:
+    - **Clear task definition** with input format expectations and output specifications
+    - **Domain-specific knowledge** that the assistant needs to know
+    - **Successful strategies** observed in correct responses
+    - **Error prevention guidance** based on the feedback patterns
+    - **Precise, actionable language** that reduces ambiguity
+
+    Focus on creating an instruction that helps the assistant avoid the specific mistakes shown in the examples while building on successful approaches."""
+
+    current_instruction = dspy.InputField(
+        desc="The current instruction that was provided to the assistant to perform the task"
+    )
+    examples_with_feedback = dspy.InputField(
+        desc="Task examples showing inputs, assistant outputs, and feedback. Read these carefully to "
+        "identify patterns, successful strategies, and specific issues that need to be addressed."
+    )
+
+    improved_instruction = dspy.OutputField(
+        desc="A better instruction for the assistant that addresses the identified issues, includes "
+        "necessary domain-specific knowledge, incorporates successful strategies, and provides "
+        "clear guidance to prevent the mistakes shown in the examples."
+    )
+
+
+class GenerateEnhancedMultimodalInstructionFromFeedback(dspy.Signature):
+    """I provided an assistant with instructions to perform a task involving visual content, but the assistant's performance needs improvement based on the examples and feedback below.
+
+    Your task is to write a better instruction for the assistant that addresses the specific issues identified in the feedback, with particular attention to how visual and textual information should be analyzed and integrated.
+
+    ## Analysis Steps:
+    1. **Read the inputs carefully** and identify both the visual and textual input formats, understanding how they work together
+    2. **Read all the assistant responses and corresponding feedback** to understand what went wrong with visual analysis, text processing, or their integration
+    3. **Identify visual analysis patterns** - what visual features, relationships, or details are important for this task
+    4. **Identify domain-specific knowledge** about both visual and textual aspects, as this information may not be available to the assistant in the future
+    5. **Look for successful visual-textual integration strategies** and include these patterns in the instruction
+    6. **Address specific visual analysis issues** mentioned in the feedback
+
+    ## Instruction Requirements:
+    - **Clear task definition** explaining how to process both visual and textual inputs
+    - **Visual analysis guidance** specific to this task (what to look for, how to describe, what features matter)
+    - **Integration strategies** for combining visual observations with textual information
+    - **Domain-specific knowledge** about visual concepts, terminology, or relationships
+    - **Error prevention guidance** for common visual analysis mistakes shown in the feedback
+    - **Precise, actionable language** for both visual and textual processing
+
+    Focus on creating an instruction that helps the assistant properly analyze visual content, integrate it with textual information, and avoid the specific visual analysis mistakes shown in the examples."""
+
+    current_instruction = dspy.InputField(
+        desc="The current instruction that was provided to the assistant to perform the multimodal task"
+    )
+    examples_with_feedback = dspy.InputField(
+        desc="Task examples with visual content showing inputs, assistant outputs, and feedback. "
+        "Pay special attention to feedback about visual analysis accuracy, visual-textual integration, "
+        "and any domain-specific visual knowledge that the assistant missed."
+    )
+
+    improved_instruction = dspy.OutputField(
+        desc="A better instruction for the assistant that addresses visual analysis issues, provides "
+        "clear guidance on how to process and integrate visual and textual information, includes "
+        "necessary visual domain knowledge, and prevents the visual analysis mistakes shown in the examples."
+    )
+
+
+class MultiModalProposer(dspy.Module):
+    """
+    dspy.Module for proposing improved instructions based on feedback.
+    """
+
+    def __init__(self):
+        super().__init__()
+        # MultiModalProposer always uses enhanced multimodal signatures
+        self.propose_instruction = dspy.Predict(GenerateEnhancedInstructionFromFeedback)
+        self.propose_multimodal_instruction = None  # Will be created if needed for multimodal content
+
+    def forward(self, current_instruction: str, reflective_dataset: list[dict[str, Any]]) -> str:
+        """
+        Generate an improved instruction based on current instruction and feedback examples.
+
+        Args:
+            current_instruction: The current instruction that needs improvement
+            reflective_dataset: List of examples with inputs, outputs, and feedback
+                               May contain dspy.Image objects in inputs
+
+        Returns:
+            str: Improved instruction text
+        """
+        # Format examples with enhanced pattern recognition
+        formatted_examples, image_map = self._format_examples_with_pattern_analysis(reflective_dataset)
+
+        # Choose appropriate predictor based on whether images are present
+        has_images = bool(image_map)
+        if has_images and self.propose_multimodal_instruction is None:
+            # Lazy initialization of multimodal predictor (enhanced multimodal signatures)
+            self.propose_multimodal_instruction = dspy.Predict(GenerateEnhancedMultimodalInstructionFromFeedback)
+
+        # Select the appropriate predictor
+        predictor = self.propose_multimodal_instruction if has_images else self.propose_instruction
+
+        # Build kwargs for the prediction call
+        predict_kwargs = {
+            "current_instruction": current_instruction,
+            "examples_with_feedback": formatted_examples,
+        }
+
+        # If we have images, add them to the context by including them in the examples_with_feedback
+        if has_images:
+            # Create a rich multimodal examples_with_feedback that includes both text and images
+            predict_kwargs["examples_with_feedback"] = self._create_multimodal_examples(formatted_examples, image_map)
+
+        # Use current dspy LM settings (GEPA will pass reflection_lm via context)
+        result = predictor(**predict_kwargs)
+
+        return result.improved_instruction
+
+    def _format_examples_with_pattern_analysis(
+        self, reflective_dataset: list[dict[str, Any]]
+    ) -> tuple[str, dict[int, list[Type]]]:
+        """
+        Format examples with pattern analysis and feedback categorization.
+
+        Returns:
+            tuple: (formatted_text_with_patterns, image_map)
+        """
+        # First, use the existing proven formatting approach
+        formatted_examples, image_map = self._format_examples_for_instruction_generation(reflective_dataset)
+
+        # Enhanced analysis: categorize feedback patterns
+        feedback_analysis = self._analyze_feedback_patterns(reflective_dataset)
+
+        # Add pattern analysis to the formatted examples
+        if feedback_analysis["summary"]:
+            pattern_summary = self._create_pattern_summary(feedback_analysis)
+            enhanced_examples = f"{pattern_summary}\n\n{formatted_examples}"
+            return enhanced_examples, image_map
+
+        return formatted_examples, image_map
+
+    def _analyze_feedback_patterns(self, reflective_dataset: list[dict[str, Any]]) -> dict[str, Any]:
+        """
+        Analyze feedback patterns to provide better context for instruction generation.
+
+        Categorizes feedback into:
+        - Error patterns: Common mistakes and their types
+        - Success patterns: What worked well and should be preserved/emphasized
+        - Domain knowledge gaps: Missing information that should be included
+        - Task-specific guidance: Specific requirements or edge cases
+        """
+        analysis = {
+            "error_patterns": [],
+            "success_patterns": [],
+            "domain_knowledge_gaps": [],
+            "task_specific_guidance": [],
+            "summary": "",
+        }
+
+        # Simple pattern recognition - could be enhanced further
+        for example in reflective_dataset:
+            feedback = example.get("Feedback", "").lower()
+
+            # Identify error patterns
+            if any(error_word in feedback for error_word in ["incorrect", "wrong", "error", "failed", "missing"]):
+                analysis["error_patterns"].append(feedback)
+
+            # Identify success patterns
+            if any(
+                success_word in feedback for success_word in ["correct", "good", "accurate", "well", "successfully"]
+            ):
+                analysis["success_patterns"].append(feedback)
+
+            # Identify domain knowledge needs
+            if any(
+                knowledge_word in feedback
+                for knowledge_word in ["should know", "domain", "specific", "context", "background"]
+            ):
+                analysis["domain_knowledge_gaps"].append(feedback)
+
+        # Create summary if patterns were found
+        if any(analysis[key] for key in ["error_patterns", "success_patterns", "domain_knowledge_gaps"]):
+            analysis["summary"] = (
+                f"Patterns identified: {len(analysis['error_patterns'])} error(s), {len(analysis['success_patterns'])} success(es), {len(analysis['domain_knowledge_gaps'])} knowledge gap(s)"
+            )
+
+        return analysis
+
+    def _create_pattern_summary(self, feedback_analysis: dict[str, Any]) -> str:
+        """Create a summary of feedback patterns to help guide instruction generation."""
+
+        summary_parts = ["## Feedback Pattern Analysis\n"]
+
+        if feedback_analysis["error_patterns"]:
+            summary_parts.append(f"**Common Issues Found ({len(feedback_analysis['error_patterns'])} examples):**")
+            summary_parts.append("Focus on preventing these types of mistakes in the new instruction.\n")
+
+        if feedback_analysis["success_patterns"]:
+            summary_parts.append(
+                f"**Successful Approaches Found ({len(feedback_analysis['success_patterns'])} examples):**"
+            )
+            summary_parts.append("Build on these successful strategies in the new instruction.\n")
+
+        if feedback_analysis["domain_knowledge_gaps"]:
+            summary_parts.append(
+                f"**Domain Knowledge Needs Identified ({len(feedback_analysis['domain_knowledge_gaps'])} examples):**"
+            )
+            summary_parts.append("Include this specialized knowledge in the new instruction.\n")
+
+        return "\n".join(summary_parts)
+
+    # Reuse the existing proven formatting methods from the original implementation
+    def _format_examples_for_instruction_generation(
+        self, reflective_dataset: list[dict[str, Any]]
+    ) -> tuple[str, dict[int, list[Type]]]:
+        """
+        Format examples using GEPA's markdown structure while preserving image objects.
+
+        Returns:
+            tuple: (formatted_text, image_map) where image_map maps example_index -> list[images]
+        """
+
+        def render_value_with_images(value, level=3, example_images=None):
+            if example_images is None:
+                example_images = []
+
+            if isinstance(value, Type):  # This includes dspy.Image
+                # Don't serialize! Keep reference and add placeholder with proper markdown formatting
+                image_idx = len(example_images) + 1
+                example_images.append(value)
+                return f"[IMAGE-{image_idx} - see visual content]\n\n"
+            elif isinstance(value, dict):
+                s = ""
+                for k, v in value.items():
+                    s += f"{'#' * level} {k}\n"
+                    s += render_value_with_images(v, min(level + 1, 6), example_images)
+                if not value:
+                    s += "\n"
+                return s
+            elif isinstance(value, (list, tuple)):
+                s = ""
+                for i, item in enumerate(value):
+                    s += f"{'#' * level} Item {i + 1}\n"
+                    s += render_value_with_images(item, min(level + 1, 6), example_images)
+                if not value:
+                    s += "\n"
+                return s
+            else:
+                return f"{str(value).strip()}\n\n"
+
+        def convert_sample_to_markdown_with_images(sample, example_num):
+            example_images = []
+            s = f"# Example {example_num}\n"
+
+            for key, val in sample.items():
+                s += f"## {key}\n"
+                s += render_value_with_images(val, level=3, example_images=example_images)
+
+            return s, example_images
+
+        # Process all examples with GEPA's markdown formatting + our image tracking
+        formatted_parts = []
+        image_map = {}
+
+        for i, example_data in enumerate(reflective_dataset):
+            formatted_example, example_images = convert_sample_to_markdown_with_images(example_data, i + 1)
+            formatted_parts.append(formatted_example)
+
+            # Store images for this example
+            if example_images:
+                image_map[i] = example_images
+
+        formatted_text = "\n\n".join(formatted_parts)
+
+        # Add visual context instruction if images are present
+        if image_map:
+            total_images = sum(len(imgs) for imgs in image_map.values())
+            formatted_text = (
+                f"The examples below include visual content ({total_images} images total). "
+                "Please analyze both the text and visual elements when suggesting improvements.\n\n" + formatted_text
+            )
+
+        return formatted_text, image_map
+
+    def _create_multimodal_examples(self, formatted_text: str, image_map: dict[int, list[Type]]) -> Any:
+        """
+        Create a multimodal input that contains both text and images for the reflection LM.
+
+        Args:
+            formatted_text: The formatted text with image placeholders
+            image_map: Dictionary mapping example_index -> list[images] for structured access
+        """
+        if not image_map:
+            return formatted_text
+
+        # Collect all images from all examples
+        all_images = []
+        for example_images in image_map.values():
+            all_images.extend(example_images)
+
+        if len(all_images) == 1:
+            # Simple case: one image total
+            return [formatted_text, all_images[0]]
+        else:
+            # Multiple images: create a rich multimodal structure
+            # The adapter system will interleave these properly in the final message
+            multimodal_content = [formatted_text]
+            multimodal_content.extend(all_images)
+            return multimodal_content

--- a/tests/teleprompt/test_gepa_instruction_proposer.py
+++ b/tests/teleprompt/test_gepa_instruction_proposer.py
@@ -1,0 +1,276 @@
+from dataclasses import dataclass
+from typing import Any
+
+import dspy
+from dspy.teleprompt.gepa import instruction_proposal
+from dspy.utils.dummies import DummyLM
+
+
+def count_messages_with_image_url_pattern(messages):
+    """Helper to count image URLs in messages - borrowed from image adapter tests"""
+    pattern = {"type": "image_url", "image_url": {"url": lambda x: isinstance(x, str)}}
+
+    try:
+
+        def check_pattern(obj, pattern):
+            if isinstance(pattern, dict):
+                if not isinstance(obj, dict):
+                    return False
+                return all(k in obj and check_pattern(obj[k], v) for k, v in pattern.items())
+            if callable(pattern):
+                return pattern(obj)
+            return obj == pattern
+
+        def count_patterns(obj, pattern):
+            count = 0
+            if check_pattern(obj, pattern):
+                count += 1
+            if isinstance(obj, dict):
+                count += sum(count_patterns(v, pattern) for v in obj.values())
+            if isinstance(obj, (list, tuple)):
+                count += sum(count_patterns(v, pattern) for v in obj)
+            return count
+
+        return count_patterns(messages, pattern)
+    except Exception:
+        return 0
+
+
+@dataclass
+class ImagesInHistory:
+    has_structured_images: bool
+    has_text_serialized_images: bool
+
+
+def check_images_in_history(history: list[Any]) -> ImagesInHistory:
+    def check_text_serialized(item: Any) -> bool:
+        if isinstance(item, list):
+            return any(check_text_serialized(i) for i in item)
+        if isinstance(item, dict):
+            return any(check_text_serialized(i) for i in item.values())
+        if isinstance(item, str):
+            return "CUSTOM-TYPE-START-IDENTIFIER" in item
+
+        return False
+
+    has_structured_images = False
+
+    for call in history:
+        if call.get("messages"):
+            image_count = count_messages_with_image_url_pattern(call["messages"])
+            if image_count > 0:
+                has_structured_images = True
+
+                break
+
+    return ImagesInHistory(
+        has_structured_images=has_structured_images,
+        has_text_serialized_images=any(check_text_serialized(i) for i in history),
+    )
+
+
+def test_reflection_lm_gets_structured_images():
+    """
+    Verify reflection LM receives structured image messages, not serialized text.
+    """
+    student = dspy.Predict("image: dspy.Image -> label: str")
+    image = dspy.Image.from_url("https://example.com/test.jpg", download=False)
+    example = dspy.Example(image=image, label="dog").with_inputs("image")
+
+    reflection_lm = DummyLM(
+        [
+            {"improved_instruction": "Better instruction"},
+            {"improved_instruction": "Enhanced visual analysis instruction"},
+            {"improved_instruction": "Focus on key features"},
+            {"improved_instruction": "Analyze visual patterns systematically"},
+            {"improved_instruction": "Consider distinctive visual elements"},
+            {"improved_instruction": "Enhance recognition accuracy"},
+            {"improved_instruction": "Improve classification methodology"},
+        ]
+    )
+    lm = DummyLM(
+        [
+            {"label": "cat"},
+            {"label": "dog"},
+            {"label": "animal"},
+            {"label": "pet"},
+            {"label": "feline"},
+            {"label": "canine"},
+            {"label": "mammal"},
+            {"label": "creature"},
+            {"label": "species"},
+            {"label": "domestic"},
+            {"label": "wild"},
+            {"label": "carnivore"},
+            {"label": "herbivore"},
+            {"label": "quadruped"},
+            {"label": "vertebrate"},
+        ]
+    )
+    dspy.settings.configure(lm=lm)
+
+    gepa = dspy.GEPA(
+        metric=lambda gold, pred, trace=None, pred_name=None, pred_trace=None: 0.3,
+        max_metric_calls=2,
+        reflection_lm=reflection_lm,
+        instruction_proposer=instruction_proposal.MultiModalProposer(),
+    )
+
+    gepa.compile(student, trainset=[example], valset=[example])
+
+    assert len(lm.history) > 0, "LM should have been called"
+    assert len(reflection_lm.history) > 0, "Reflection LM should have been called"
+
+    images_in_history = check_images_in_history(reflection_lm.history)
+
+    assert images_in_history.has_structured_images, "Reflection LM should have received structured images"
+    assert not images_in_history.has_text_serialized_images, "Reflection LM received serialized images in prompts"
+
+
+def test_image_serialization_into_strings():
+    """
+    Test that demonstrates the image serialization problem when calling lm directly with serialized image data.
+    """
+
+    class InstructionProposerCallingLMDirectly(dspy.Module):
+        def forward(self, current_instruction: str, reflective_dataset: list[dict[str, Any]]) -> str:
+            feedback_analysis = "Feedback analysis:\n"
+
+            for i, example in enumerate(reflective_dataset):
+                feedback_analysis += f"Example {i + 1}:\n"
+
+                # Non ideal approach: extract and serialize image objects directly
+                inputs = example.get("Inputs", {})
+                for key, value in inputs.items():
+                    feedback_analysis += f"  {key}: {value}\n"
+
+                outputs = example.get("Generated Outputs", {})
+                feedback = example.get("Feedback", "")
+                feedback_analysis += f"  Outputs: {outputs}\n"
+                feedback_analysis += f"  Feedback: {feedback}\n\n"
+
+            context_lm = dspy.settings.lm
+            messages = [
+                {"role": "system", "content": "You are an instruction improvement assistant."},
+                {
+                    "role": "user",
+                    "content": f"Current instruction: {current_instruction}\n\nFeedback: {feedback_analysis}\n\nProvide an improved instruction:",
+                },
+            ]
+
+            result = context_lm(messages=messages)
+
+            return result[0]
+
+    direct_lm_call_proposer = InstructionProposerCallingLMDirectly()
+
+    student = dspy.Predict("image -> label")
+
+    image = dspy.Image.from_url("https://picsum.photos/id/237/200/300", download=False)
+
+    examples = [
+        dspy.Example(image=image, label="cat").with_inputs("image"),
+        dspy.Example(image=image, label="animal").with_inputs("image"),
+    ]
+
+    lm = DummyLM(
+        [
+            {"label": "cat"},
+            {"label": "dog"},
+            {"label": "animal"},
+            {"label": "pet"},
+            {"label": "feline"},
+            {"label": "mammal"},
+            {"label": "creature"},
+            {"label": "species"},
+            {"label": "domestic"},
+            {"label": "wild"},
+            {"label": "carnivore"},
+            {"label": "herbivore"},
+        ]
+    )
+    dspy.settings.configure(lm=lm)
+
+    reflection_lm = DummyLM(
+        [
+            {"improved_instruction": "Be more specific about image analysis"},
+            {"improved_instruction": "Focus on visual features when classifying"},
+            {"improved_instruction": "Consider contextual clues in the image"},
+            {"improved_instruction": "Analyze shape, color, and texture patterns"},
+            {"improved_instruction": "Look for distinguishing characteristics"},
+        ]
+    )
+
+    gepa = dspy.GEPA(
+        metric=lambda gold, pred, trace=None, pred_name=None, pred_trace=None: 0.3,
+        max_metric_calls=5,
+        reflection_lm=reflection_lm,
+        instruction_proposer=direct_lm_call_proposer,
+    )
+
+    gepa.compile(student, trainset=examples, valset=examples)
+
+    assert len(lm.history) > 0, "LM should have been called"
+    assert len(reflection_lm.history) > 0, "Reflection LM should have been called"
+
+    images_in_history = check_images_in_history(reflection_lm.history)
+
+    assert images_in_history.has_text_serialized_images, (
+        "Expected to find serialized images (CUSTOM-TYPE-START-IDENTIFIER)"
+    )
+
+
+def test_default_proposer():
+    student = dspy.Predict("image -> label")
+
+    image = dspy.Image.from_url("https://picsum.photos/id/237/200/300", download=False)
+
+    examples = [
+        dspy.Example(image=image, label="cat").with_inputs("image"),
+        dspy.Example(image=image, label="animal").with_inputs("image"),
+    ]
+
+    lm = DummyLM(
+        [
+            {"label": "cat"},
+            {"label": "dog"},
+            {"label": "animal"},
+            {"label": "pet"},
+            {"label": "feline"},
+            {"label": "mammal"},
+            {"label": "creature"},
+            {"label": "species"},
+            {"label": "domestic"},
+            {"label": "wild"},
+            {"label": "carnivore"},
+            {"label": "herbivore"},
+        ]
+    )
+    dspy.settings.configure(lm=lm)
+
+    reflection_lm = DummyLM(
+        [
+            {"improved_instruction": "Be more specific about image analysis"},
+            {"improved_instruction": "Focus on visual features when classifying"},
+            {"improved_instruction": "Consider contextual clues in the image"},
+            {"improved_instruction": "Analyze shape, color, and texture patterns"},
+            {"improved_instruction": "Look for distinguishing characteristics"},
+        ]
+    )
+
+    gepa = dspy.GEPA(
+        metric=lambda gold, pred, trace=None, pred_name=None, pred_trace=None: 0.3,
+        max_metric_calls=5,
+        reflection_lm=reflection_lm,
+    )
+
+    gepa.compile(student, trainset=examples, valset=examples)
+
+    assert len(lm.history) > 0, "LM should have been called"
+    assert len(reflection_lm.history) > 0, "Reflection LM should have been called"
+
+    images_in_history = check_images_in_history(reflection_lm.history)
+
+    assert images_in_history.has_text_serialized_images, (
+        "Expected to find serialized images (CUSTOM-TYPE-START-IDENTIFIER)"
+    )


### PR DESCRIPTION
Closes https://github.com/stanfordnlp/dspy/issues/8690

# Add support for custom instruction proposers in GEPA with multimodal handling.

As proposed by @LakshyAAAgrawal, this PR makes GEPA’s instruction-proposal step pluggable. Users can supply a custom instruction proposer, enabling GEPA to handle dspy.Image and other custom types.

## Key Features

- **Custom Instruction Proposer Protocol**: New `InstructionProposerProtocol` for implementing custom instruction generation
- **MultiModalProposer**: Built-in proposer that handles multimodal inputs (text + images) during optimization
- **Structured Image Handling**: Preserves `dspy.Image` objects without serialization in reflection LM calls
- **Backward Compatibility**: Existing GEPA usage continues to work unchanged

## Usage

### For multi-modal use cases

```python
import dspy
from dspy.teleprompt.gepa.instruction_proposal import MultiModalProposer

# Configure your language models
lm = dspy.LM(model='gpt-4o-mini')
reflection_lm = dspy.LM(model='gpt-4o', temperature=1.0, max_tokens=32000)

# Create a student module that uses images
class ImageClassifier(dspy.Module):
    def __init__(self):
        super().__init__()
        self.classify = dspy.Predict("image: dspy.Image -> label: str")
    
    def forward(self, image):
        return self.classify(image=image)

# Set up GEPA with custom instruction proposer
gepa = dspy.GEPA(
    metric=your_metric_function,
    max_metric_calls=50,
    reflection_lm=reflection_lm,
    instruction_proposer=MultiModalProposer()  # Enable multimodal support
)

# Compile with image data
student = ImageClassifier()
compiled_student = gepa.compile(student, trainset=image_trainset, valset=image_valset)
```

### Advanced: Custom Instruction Proposer

You can implement your own instruction proposer by following the protocol:

```python
from dspy.teleprompt.gepa.instruction_proposal import InstructionProposerProtocol

class MyCustomProposer:
    def __call__(self, current_instruction: str, reflective_dataset: list[dict]) -> str:
        # Your custom logic here
        # reflective_dataset contains examples with inputs, outputs, and feedback
        # May include dspy.Image objects in inputs
        
        # Analyze the feedback and generate improved instruction
        improved_instruction = analyze_and_improve(current_instruction, reflective_dataset)
        return improved_instruction

# Use with GEPA
gepa = dspy.GEPA(
    metric=your_metric,
    max_metric_calls=50,
    reflection_lm=reflection_lm,
    instruction_proposer=MyCustomProposer()
)
```

## Backward Compatibility

This change is fully backward compatible. Existing GEPA code will continue to work without modification:

```python
# This still works exactly as before
gepa = dspy.GEPA(metric=my_metric, max_metric_calls=50, reflection_lm=reflection_lm)
compiled = gepa.compile(student, trainset, valset)
```

## Files Changed

- `dspy/teleprompt/gepa/gepa.py`: Add `instruction_proposer` parameter
- `dspy/teleprompt/gepa/gepa_utils.py`: Integrate custom proposer logic and preserve image objects
- `dspy/teleprompt/gepa/instruction_proposal.py`: New multimodal instruction proposer implementation
- `tests/teleprompt/test_gepa_instruction_proposer.py`

This enables GEPA optimization to work with visual content while maintaining proper image handling throughout the reflection and instruction proposal process.